### PR TITLE
Optimize cache control in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,7 +100,9 @@ RUN cpan -T -i \
     YAML \
     Net::SSH::Perl
 
+ARG UMI_TAG
 RUN git clone https://github.com/z-eos/umi.git && \
+    if [ -n "$UMI_TAG" ]; then git -C /umi checkout $UMI_TAG; else true; fi && \
     catalyst.pl umi && \
     cd /umi && perl Makefile.PL && make
 


### PR DESCRIPTION
* docker/Dockerfile: New build arg UMI_TAG sets the tag or hash of
the commit to be built.  This allows, in particular, for cleaning
cache before building.